### PR TITLE
wezterm + tmux: launch nu in every pane

### DIFF
--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -1,5 +1,6 @@
 # source-file ~/.config/tmux/tmux.reset.conf
 set-option -g default-terminal 'screen-256color'
+set-option -g default-command '/opt/homebrew/bin/nu'
 # set-option -g terminal-overrides ',xterm-256color:RGB'
 #
 set -g prefix C-b

--- a/wezterm/.wezterm.lua
+++ b/wezterm/.wezterm.lua
@@ -4,6 +4,9 @@ local wezterm = require("wezterm")
 -- This will hold the configuration.
 local config = wezterm.config_builder()
 
+-- Launch tmux directly; tmux is configured to spawn nu per pane.
+config.default_prog = { "/opt/homebrew/bin/tmux" }
+
 config.initial_cols = 80
 config.initial_rows = 28
 


### PR DESCRIPTION
## Summary

Wires the nushell port (merged in #2) into the wezterm → tmux chain so every pane is nu + fastfetch instead of zsh:

- **`wezterm/.wezterm.lua`** — `default_prog = { "/opt/homebrew/bin/tmux" }` so wezterm launches tmux directly, skipping the login shell.
- **`tmux/.tmux.conf`** — `set-option -g default-command '/opt/homebrew/bin/nu'` so tmux panes spawn nu rather than `$SHELL`.

Login shell stays as zsh — anything calling `$SHELL -c …` (asdf, VS Code tasks, etc.) still gets a POSIX shell. The change is macOS-only by virtue of the hard-coded `/opt/homebrew` paths.

## Test plan

- [ ] Open a fresh wezterm window: should land in tmux with nu + fastfetch in the first pane
- [ ] `prefix |` / `prefix -` open new panes that also start in nu
- [ ] `echo $SHELL` (in a non-tmux context) still reports zsh
- [ ] BATS suite still green (no test changes needed — these are pure config edits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)